### PR TITLE
Added Demo App changes for Mono/Stereo Audio Mode and Updated SDK Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [0.13.1] - 2021-11-11
 
+### Added
+* Added APIs for Audio Video configuration i.e `AudioVideoConfiguration` to be used during a meeting session.
+* Added support for joining meetings without audio i.e `AudioMode.NoAudio` or with audio using one of `AudioMode.Mono16K`, `AudioMode.Mono48K` and `AudioMode.Stereo48K` audio modes.
+* **Breaking** The `AudioMode.Stereo48K` will be set as the default audio mode if not explicitly specified when starting the audio session. Earlier, Mono/16KHz audio was the default and the only audio mode supported.
+* Added an optional method `onAttendeesJoinedWithoutAudio` in `RealtimeObserver` to communicate the status of attendees who joined without audio.
+* [Demo] Added ways to join a meeting without audio or with audio using various audio modes.
+
 ### Fixed
 * [Demo] Fixed demo app crashes when screen share is off and then leave meeting.
 
@@ -10,11 +17,7 @@
 ## [0.13.0] - 2021-11-01
 
 ### Added
-* Added APIs for Audio Video configuration i.e `AudioVideoConfiguration` to be used during a meeting session.
-* Added support for joining meetings without audio i.e `AudioMode.NoAudio`.
-* Added an optional method `onAttendeesJoinedWithoutAudio` in `RealtimeObserver` to communicate the status of attendees who joined without audio.
 * Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
-* [Demo] Added a way to join a meeting without audio.
 * [Demo] Added meeting captions functionality based on the live transcription APIs. You will need to have a serverless deployment to create new AWS Lambda endpoints for live transcription. Follow [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html) to create necessary service-linked role so that the demo app can call Amazon Transcribe and Amazon Transcribe Medical on your behalf.
 
 ## [0.12.0] - 2021-09-02

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ You need to start the meeting session to start sending and receiving audio. Make
 meetingSession.audioVideo.start()
 ```
 
+The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
+
+```kotlin
+meetingSession.audioVideo.start(audioVideoConfiguration)
+```
+
 #### Use case 2. Add an observer to receive audio and video session life cycle events.
 
 > Note: To avoid missing any events, add an observer before the session starts. You can remove the observer by calling meetingSession.audioVideo.removeAudioVideoObserver(observer).
@@ -249,11 +255,21 @@ override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
 
 ### Audio
 
-> Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
+#### Use case 8. Choose the audio configuration.
+
 > Attendees can join a meeting with or without audio.
+> When joining a meeting with audio, *Mono/16KHz*, *Mono/48KHz* and *Stereo/48KHz* are supported. *Stereo/48KHz* will be set as the default audio mode if not explicitly specified when starting the audio session.
 > Attendees who join without audio aka Checked-In attendees will have no audio through their Mic and Speaker. They can still enable their video and view videos of other attendees. No volume and signal updates for Checked-In attendees will be delivered to other attendees in the meeting. Attendees may want to join a meeting without audio if they just want to be shown as present in the meeting and share or view videos but are using a different audio source. For example, multiple attendees joining a meeting from a conference room may want to use common audio source installed in the conference room.
 
-#### Use case 8. Mute and unmute an audio input.
+```kotlin
+meetingSession.audioVideo.start() // starts the audio video session with Stereo/48KHz audio
+
+meetingSession.audioVideo.start(audioVideoConfiguration) // starts the audio video session with the specified [AudioVideoConfiguration]
+```
+
+> Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
+
+#### Use case 9. Mute and unmute an audio input.
 
 ```kotlin
 val muted = meetingSession.audioVideo.realtimeLocalMute() // returns true if muted, false if failed
@@ -261,7 +277,7 @@ val muted = meetingSession.audioVideo.realtimeLocalMute() // returns true if mut
 val unmuted = meetingSession.audioVideo.realtimeLocalUnmute() // returns true if unmuted, false if failed
 ```
 
-#### Use case 9. Add an observer to receive realtime events such as volume changes/signal change/muted status attendees.
+#### Use case 10. Add an observer to receive realtime events such as volume changes/signal change/muted status attendees.
 
 You can use this to build real-time indicators UI and get them updated for changes delivered by the array.
 
@@ -314,7 +330,7 @@ val observer = object : RealtimeObserver {
 meetingSession.audioVideo.addRealtimeObserver(observer)
 ```
 
-#### Use case 10. Detect active speakers and active scores of speakers.
+#### Use case 11. Detect active speakers and active scores of speakers.
 
 You can use the `onActiveSpeakerDetected` event to enlarge or emphasize the most active speaker’s video tile if available. By setting the `scoreCallbackIntervalMs` and implementing `onActiveSpeakerScoreChanged`, you can receive scores of the active speakers periodically.
 
@@ -352,7 +368,7 @@ meetingSession.audioVideo.addActiveSpeakerObserver(DefaultActiveSpeakerPolicy(),
 
 You can find more details on adding/removing/viewing video from [Building a meeting application on android using the Amazon Chime SDK](https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-on-android-using-the-amazon-chime-sdk/).
 
-#### Use case 11. Start receiving remote videos.
+#### Use case 12. Start receiving remote videos.
 
 You can call `startRemoteVideo` to start receiving remote videos, as this doesn’t happen by default.
 
@@ -360,7 +376,7 @@ You can call `startRemoteVideo` to start receiving remote videos, as this doesn�
 meetingSession.audioVideo.startRemoteVideo()
 ```
 
-#### Use case 12. Stop receiving remote videos.
+#### Use case 13. Stop receiving remote videos.
 
 `stopRemoteVideo` stops receiving remote videos and triggers `onVideoTileRemoved` for existing remote videos.
 
@@ -368,7 +384,7 @@ meetingSession.audioVideo.startRemoteVideo()
 meetingSession.audioVideo.stopRemoteVideo()
 ```
 
-#### Use case 13. View remote videos.
+#### Use case 14. View remote videos.
 
 ```kotlin
 val observer = object : VideoTileObserver {
@@ -391,7 +407,7 @@ meetingSession.audioVideo.addVideoTileObserver(observer)
 
 For more advanced video tile management, take a look at [Video Pagination](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/video_pagination.md).
 
-#### Use case 14. Start sharing your video.
+#### Use case 15. Start sharing your video.
 
 ```kotlin
 // Use internal camera capture for the local video
@@ -403,13 +419,13 @@ meetingSession.audioVideo.switchCamera()
 // Or you can inject custom video source for local video, see custom video guide
 ```
 
-#### Use case 15. Stop sharing your video.
+#### Use case 16. Stop sharing your video.
 
 ```kotlin
 meetingSession.audioVideo.stopLocalVideo()
 ```
 
-#### Use case 16. View local video.
+#### Use case 17. View local video.
 
 ```kotlin
 val observer = object : VideoTileObserver {
@@ -440,7 +456,7 @@ meetingSession.audioVideo.addVideoTileObserver(observer)
 >
 > For example, your attendee ID is "my-id". When you call `meetingSession.audioVideo.startContentShare`, the content attendee "my-id#content" will join the session and share your content.
 
-#### Use case 17. Start sharing your screen or content.
+#### Use case 18. Start sharing your screen or content.
 
 ```kotlin
 val observer = object : ContentShareObserver {
@@ -461,13 +477,13 @@ meetingSession.audioVideo.startContentShare(contentShareSource)
 
 See [Content Share](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for more details.
 
-#### Use case 18. Stop sharing your screen or content.
+#### Use case 19. Stop sharing your screen or content.
 
 ```kotlin
 meetingSession.audioVideo.stopContentShare()
 ```
 
-#### Use case 19. View attendee content or screens.
+#### Use case 20. View attendee content or screens.
 
 Chime SDK allows two simultaneous content shares per meeting. Remote content shares will trigger `onVideoTileAdded`, while local share will not. To render the video for preview, add a `VideoSink` to the `VideoSource` in the `ContentShareSource`.
 
@@ -497,7 +513,7 @@ meetingSession.audioVideo.addVideoTileObserver(observer)
 
 ### Metrics
 
-#### Use case 20. Add an observer to receive the meeting metrics.
+#### Use case 21. Add an observer to receive the meeting metrics.
 
 See `ObservableMetric` for more available metrics and to monitor audio, video, and content share quality.
 
@@ -515,7 +531,7 @@ meetingSession.audioVideo.addMetricsObserver(observer)
 
 ### Data Message
 
-#### Use case 21. Add  an observer to receive data message.
+#### Use case 22. Add  an observer to receive data message.
 
 You can receive real-time messages from multiple topics after starting the meeting session.
 
@@ -537,7 +553,7 @@ const val DATA_MESSAGE_TOPIC = "chat"
 meetingSession.audioVideo.addRealtimeDataMessageObserver(DATA_MESSAGE_TOPIC, observer)
 ```
 
-#### Use case 22. Send data message.
+#### Use case 23. Send data message.
 
 You can send real time message to any topic, to which the observers that have subscribed will be notified.
 
@@ -559,7 +575,7 @@ meetingSession.audioVideo.realtimeSendDataMessage(
 
 > Note: Make sure to remove all the observers and release resources you have added to avoid any memory leaks.
 
-#### Use case 23. Stop a session.
+#### Use case 24. Stop a session.
 
 ```kotlin
 val observer = object: AudioVideoObserver {  
@@ -581,7 +597,7 @@ meetingSession.audioVideo.stop()
 
 Amazon Voice Focus reduces the background noise in the meeting for better meeting experience. For more details, see [Amazon Voice Focus](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/api_overview.md#11-using-amazon-voice-focus-optional).
 
-#### Use case 24. Enable/Disable Amazon Voice Focus.
+#### Use case 25. Enable/Disable Amazon Voice Focus.
 
 ```kotlin
 val enbabled = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(true) // enabling Amazon Voice Focus successful

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
@@ -15,5 +15,5 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
  * a meeting session.
  */
 data class AudioVideoConfiguration @JvmOverloads constructor(
-    val audioMode: AudioMode = AudioMode.Mono
+    val audioMode: AudioMode = AudioMode.Stereo48K
 )

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -15,9 +15,19 @@ enum class AudioMode(val value: Int) {
     NoAudio(0),
 
     /**
-     * The default audio mode with single audio channel.
+     * The mono audio mode with single audio channel and 16KHz sampling rate.
      */
-    Mono(1);
+    Mono16K(1),
+
+    /**
+     * The mono audio mode with single audio channel and 48KHz sampling rate.
+     */
+    Mono48K(2),
+
+    /**
+     * The stereo audio mode with two audio channels and 48KHz sampling rate.
+     */
+    Stereo48K(3);
 
     companion object {
         fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -20,6 +20,7 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.AudioClient.AudioModeInternal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -50,7 +51,7 @@ class DefaultAudioClientController(
         var audioClientState = AudioClientState.INITIALIZED
     }
 
-    private fun setUpAudioConfiguration() {
+    private fun setUpAudioConfiguration(audioMode: AudioMode) {
         // There seems to be no call that gives us the native input sample rate, so we just use the output rate
         val nativeSR = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_SYSTEM)
 
@@ -58,15 +59,28 @@ class DefaultAudioClientController(
         audioClient.sendMessage(AudioClient.MESS_SET_HARDWARE_SAMPLE_RATE, nativeSR)
 
         // This IO_SAMPLE_RATE is used to create OpenSLES:
+        val samplingRateConfig = when (audioMode) {
+            AudioMode.NoAudio -> 16000
+            AudioMode.Mono16K -> 16000
+            AudioMode.Mono48K -> 48000
+            AudioMode.Stereo48K -> 48000
+        }
         audioClient.sendMessage(
             AudioClient.MESS_SET_IO_SAMPLE_RATE,
-            AudioClient.AUDIO_CLIENT_SAMPLE_RATE
+            samplingRateConfig
         )
 
         // Result is in bytes, so we divide by 2 (16-bit samples)
+        // Result is in bytes, so we divide by 2 (16-bit samples)
+        val channelConfig = when (audioMode) {
+            AudioMode.NoAudio -> AudioFormat.CHANNEL_OUT_MONO
+            AudioMode.Mono16K -> AudioFormat.CHANNEL_OUT_MONO
+            AudioMode.Mono48K -> AudioFormat.CHANNEL_OUT_MONO
+            AudioMode.Stereo48K -> AudioFormat.CHANNEL_OUT_STEREO
+        }
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
-            AudioFormat.CHANNEL_OUT_MONO,
+            channelConfig,
             AudioFormat.ENCODING_PCM_16BIT
         ) / 2
 
@@ -138,7 +152,7 @@ class DefaultAudioClientController(
             )
             DEFAULT_PORT
         }
-        setUpAudioConfiguration()
+        setUpAudioConfiguration(audioMode)
         eventAnalyticsController.publishEvent(EventName.meetingStartRequested)
         audioClientObserver.notifyAudioClientObserver { observer ->
             observer.onAudioSessionStartedConnecting(
@@ -152,6 +166,12 @@ class DefaultAudioClientController(
         uiScope.launch {
             muteMicAndSpeaker = audioMode == AudioMode.NoAudio
 
+            val audioModeInternal = when (audioMode) {
+                AudioMode.NoAudio -> AudioModeInternal.NO_AUDIO
+                AudioMode.Mono16K -> AudioModeInternal.MONO_16K
+                AudioMode.Mono48K -> AudioModeInternal.MONO_48K
+                AudioMode.Stereo48K -> AudioModeInternal.STEREO_48K
+            }
             val res = audioClient.startSessionV2(
                 AudioClient.XTL_DEFAULT_TRANSPORT,
                 host,
@@ -159,14 +179,13 @@ class DefaultAudioClientController(
                 joinToken,
                 meetingId,
                 attendeeId,
-                AudioClient.kCodecOpusLow,
-                AudioClient.kCodecOpusLow,
                 muteMicAndSpeaker,
                 muteMicAndSpeaker,
                 DEFAULT_PRESENTER,
                 audioFallbackUrl,
                 null,
-                appInfo
+                appInfo,
+                audioModeInternal
             )
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class AudioVideoConfigurationTest {
     @Test
-    fun `default audio mode should be mono`() {
-        Assert.assertEquals(AudioVideoConfiguration().audioMode, AudioMode.Mono)
+    fun `default audio mode should be stereo`() {
+        Assert.assertEquals(AudioVideoConfiguration().audioMode, AudioMode.Stereo48K)
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -86,13 +86,13 @@ class DefaultAudioVideoControllerTest {
                 meetingId,
                 attendeeId,
                 joinToken,
-                AudioMode.Mono
+                AudioMode.Stereo48K
             )
         }
     }
 
     @Test
-    fun `start with audio video configuration should call audioClientController start with the parameters in configuration`() {
+    fun `start with no audio should call audioClientController start with the parameters in configuration and no audio`() {
         val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.NoAudio)
         audioVideoController.start(testAudioVideoConfiguration)
         verify {
@@ -103,6 +103,54 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.NoAudio
+            )
+        }
+    }
+
+    @Test
+    fun `start with mono 16KHz should call audioClientController start with the parameters in configuration and mono 16KHz`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.Mono16K)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                    audioFallbackURL,
+                    audioHostURL,
+                    meetingId,
+                    attendeeId,
+                    joinToken,
+                    AudioMode.Mono16K
+            )
+        }
+    }
+
+    @Test
+    fun `start with mono 48KHz should call audioClientController start with the parameters in configuration and mono 48KHz`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.Mono48K)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                    audioFallbackURL,
+                    audioHostURL,
+                    meetingId,
+                    attendeeId,
+                    joinToken,
+                    AudioMode.Mono48K
+            )
+        }
+    }
+
+    @Test
+    fun `start with stereo 48KHz should call audioClientController start with the parameters in configuration and stereo 48KHz`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.Stereo48K)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                    audioFallbackURL,
+                    audioHostURL,
+                    meetingId,
+                    attendeeId,
+                    joinToken,
+                    AudioMode.Stereo48K
             )
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
@@ -7,7 +7,9 @@ class AudioModeTest {
     @Test
     fun `get enum value from int`() {
         Assert.assertEquals(AudioMode.from(0), AudioMode.NoAudio)
-        Assert.assertEquals(AudioMode.from(1), AudioMode.Mono)
+        Assert.assertEquals(AudioMode.from(1), AudioMode.Mono16K)
+        Assert.assertEquals(AudioMode.from(2), AudioMode.Mono48K)
+        Assert.assertEquals(AudioMode.from(3), AudioMode.Stereo48K)
     }
 
     @Test
@@ -17,6 +19,6 @@ class AudioModeTest {
 
     @Test
     fun `get enum value from int with fallback to default value`() {
-        Assert.assertEquals(AudioMode.from(-1, AudioMode.Mono), AudioMode.Mono)
+        Assert.assertEquals(AudioMode.from(-1, AudioMode.Stereo48K), AudioMode.Stereo48K)
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -20,6 +20,7 @@ import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AppInfo
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.AudioClient.AudioModeInternal
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -126,7 +127,6 @@ class DefaultAudioClientControllerTest {
         every { mockAudioClient.sendMessage(any(), any()) } returns testAudioClientSuccessCode
         every {
             mockAudioClient.startSessionV2(
-                any(),
                 any(),
                 any(),
                 any(),
@@ -285,7 +285,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start should call AudioClient startSessionV2 with mute mic and speaker as false`() {
+    fun `start with Stereo 48KHz should call AudioClient startSessionV2 with Stereo 48KHz and mute mic and speaker as false`() {
         setupStartTests()
 
         audioClientController.start(
@@ -294,7 +294,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
 
         verify {
@@ -305,20 +305,83 @@ class DefaultAudioClientControllerTest {
                 any(),
                 any(),
                 any(),
-                any(),
-                any(),
                 false,
                 false,
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                AudioModeInternal.STEREO_48K
             )
         }
     }
 
     @Test
-    fun `start with no audio should call AudioClient startSessionV2 with mute mic and speaker as true`() {
+    fun `start with Mono 16KHz should call AudioClient startSessionV2 with Mono 16KHz and mute mic and speaker as false`() {
+        setupStartTests()
+
+        audioClientController.start(
+                testAudioFallbackUrl,
+                testAudioHostUrl,
+                testMeetingId,
+                testAttendeeId,
+                testJoinToken,
+                AudioMode.Mono16K
+        )
+
+        verify {
+            mockAudioClient.startSessionV2(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    false,
+                    false,
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    AudioModeInternal.MONO_16K
+            )
+        }
+    }
+
+    @Test
+    fun `start with Mono 48KHz should call AudioClient startSessionV2 with Mono 48KHz and mute mic and speaker as false`() {
+        setupStartTests()
+
+        audioClientController.start(
+                testAudioFallbackUrl,
+                testAudioHostUrl,
+                testMeetingId,
+                testAttendeeId,
+                testJoinToken,
+                AudioMode.Mono48K
+        )
+
+        verify {
+            mockAudioClient.startSessionV2(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    false,
+                    false,
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    AudioModeInternal.MONO_48K
+            )
+        }
+    }
+
+    @Test
+    fun `start with No Audio should call AudioClient startSessionV2 with No Audio and  mute mic and speaker as true`() {
         setupStartTests()
 
         audioClientController.start(
@@ -338,14 +401,13 @@ class DefaultAudioClientControllerTest {
                 any(),
                 any(),
                 any(),
-                any(),
-                any(),
                 true,
                 true,
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                AudioModeInternal.NO_AUDIO
             )
         }
     }
@@ -360,7 +422,7 @@ class DefaultAudioClientControllerTest {
                 testMeetingId,
                 testAttendeeId,
                 testJoinToken,
-                AudioMode.Mono
+                AudioMode.Stereo48K
         )
 
         verify {
@@ -378,7 +440,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
 
         verify(exactly = 1) { mockAudioClientObserver.notifyAudioClientObserver(any()) }
@@ -393,7 +455,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
 
         verify(exactly = 1) { mockEventAnalyticsController.publishEvent(EventName.meetingStartRequested, any()) }
@@ -418,7 +480,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -436,7 +498,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -458,7 +520,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
 
         val enableOutput: Boolean = audioClientController.setVoiceFocusEnabled(true)
@@ -492,7 +554,7 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Mono
+            AudioMode.Stereo48K
         )
 
         audioClientController.isVoiceFocusEnabled()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -10,11 +10,13 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.View
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
@@ -52,10 +54,12 @@ class HomeActivity : AppCompatActivity() {
 
     private var meetingEditText: EditText? = null
     private var nameEditText: EditText? = null
+    private var audioMode: AppCompatSpinner? = null
     private var authenticationProgressBar: ProgressBar? = null
     private var meetingID: String? = null
     private var yourName: String? = null
     private var testUrl: String = ""
+    private var audioModes = listOf("Stereo/48KHz Audio", "Mono/48KHz Audio", "Mono/16KHz Audio", "No Audio")
     private lateinit var audioVideoConfig: AudioVideoConfiguration
     private lateinit var debugSettingsViewModel: DebugSettingsViewModel
 
@@ -72,15 +76,12 @@ class HomeActivity : AppCompatActivity() {
 
         meetingEditText = findViewById(R.id.editMeetingId)
         nameEditText = findViewById(R.id.editName)
+        audioMode = findViewById(R.id.audioModeSpinner)
         authenticationProgressBar = findViewById(R.id.progressAuthentication)
         debugSettingsViewModel = ViewModelProvider(this).get(DebugSettingsViewModel::class.java)
 
+        audioMode?.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, audioModes)
         findViewById<Button>(R.id.buttonContinue)?.setOnClickListener {
-            audioVideoConfig = AudioVideoConfiguration()
-            joinMeeting()
-        }
-        findViewById<Button>(R.id.buttonContinueWithoutAudio)?.setOnClickListener {
-            audioVideoConfig = AudioVideoConfiguration(audioMode = AudioMode.NoAudio)
             joinMeeting()
         }
         findViewById<Button>(R.id.buttonDebugSettings)?.setOnClickListener { showDebugSettings() }
@@ -95,6 +96,13 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun joinMeeting() {
+        when (audioMode?.selectedItemPosition ?: 0) {
+            0 -> audioVideoConfig = AudioVideoConfiguration(audioMode = AudioMode.Stereo48K)
+            1 -> audioVideoConfig = AudioVideoConfiguration(audioMode = AudioMode.Mono48K)
+            2 -> audioVideoConfig = AudioVideoConfiguration(audioMode = AudioMode.Mono16K)
+            3 -> audioVideoConfig = AudioVideoConfiguration(audioMode = AudioMode.NoAudio)
+        }
+
         meetingID = meetingEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")
         yourName = nameEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")
         testUrl = getTestUrl()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -56,8 +56,8 @@ class MeetingActivity : AppCompatActivity(),
         meetingId = intent.extras?.getString(HomeActivity.MEETING_ID_KEY) as String
         name = intent.extras?.getString(HomeActivity.NAME_KEY) as String
         val audioMode = intent.extras?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
-            AudioMode.from(intValue, defaultAudioMode = AudioMode.Mono)
-        } ?: AudioMode.Mono
+            AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
+        } ?: AudioMode.Stereo48K
         audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode)
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -110,8 +110,8 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
         val meetingId = arguments?.getString(HomeActivity.MEETING_ID_KEY)
         val name = arguments?.getString(HomeActivity.NAME_KEY)
         val audioMode = arguments?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
-            AudioMode.from(intValue, defaultAudioMode = AudioMode.Mono)
-        } ?: AudioMode.Mono
+            AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
+        } ?: AudioMode.Stereo48K
         audioVideo = (activity as MeetingActivity).getAudioVideo()
 
         val displayedText = getString(R.string.preview_meeting_info, meetingId, name)

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -264,8 +264,8 @@ class MeetingFragment : Fragment(),
         selectTab(meetingModel.tabIndex)
         setupAudioVideoFacadeObservers()
         val audioMode = arguments?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
-            AudioMode.from(intValue, defaultAudioMode = AudioMode.Mono)
-        } ?: AudioMode.Mono
+            AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
+        } ?: AudioMode.Stereo48K
         val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode)
         // Update the Mic & Speaker states
         updateLocalAttendeeAudioState(audioEnabled = audioVideoConfig.audioMode != AudioMode.NoAudio)

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -42,21 +42,19 @@
         android:inputType="text"
         android:textAlignment="center" />
 
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/audioModeSpinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/audio_mode_spinner"
+        android:layout_gravity="center"/>
+
     <Button
         android:id="@+id/buttonContinue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/join_with_audio"
+        android:text="@string/join_meeting"
         android:contentDescription="@string/main_continue"
-        android:gravity="center"
-        android:layout_gravity="center"/>
-
-    <Button
-        android:id="@+id/buttonContinueWithoutAudio"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/join_without_audio"
-        android:contentDescription="@string/main_continue_without_audio"
         android:gravity="center"
         android:layout_gravity="center"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,10 +8,10 @@
     <string name="edit_meeting_id">Meeting ID</string>
     <string name="edit_name">Your Name</string>
     <string name="main_title">Join a meeting</string>
+    <string name="audio_mode_spinner">Audio Mode</string>
     <string name="main_continue">Continue</string>
     <string name="main_continue_without_audio">Continue without audio</string>
-    <string name="join_with_audio">Join with audio</string>
-    <string name="join_without_audio">Join without audio</string>
+    <string name="join_meeting">Join Meeting</string>
     <string name="main_debug_settings">Debug Settings</string>
     <string name="additional_options">Additional Options</string>
     <string name="meeting_leave">Leave Meeting</string>


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
**SDK**
* Updated `AudioMode` enum with values `Stereo48K`, `Mono48K`, `Mono16K` and `NoAudio`
> * The  `Stereo48K` corresponds to 48KHz Stereo Audio
> * The  `Mono48K` corresponds to 48KHz Mono Audio
> * The  `Mono16K` corresponds to 16KHz Mono Audio
> * The  `NoAudio` corresponds to No Audio
* The *Stereo/48KHz* Audio will now be the default Audio Mode, if none is explicitly specified when starting the audio session. Historically, the default and the only Audio Mode has been *Mono/16KHz* Audio.
* The Audio Mode specified when starting the audio session will be passed onto the Audio Client when calling the `startSession` API.
* Updated Unit Tests
* Updated README and CHANGELOG.

**Demo App**
* Removed the Join without Audio button, and instead added a Spinner in the `HomeActivity` to pick the Audio Mode when joining a meeting.

### Testing done:
#### Unit test coverage
* Class coverage: 82%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

Following are the manual testing scenarios performed by Audio Team (@zhemitu-amzn)
* Tested joining meeting with Stereo/48KHz
* Tested joining meeting with Mono/48KHz
* Tested joining meeting with Mono/16KHz
* Tested joining meeting with No Audio

*Endpoint Used for Testing: https://wmvhgew0bi.execute-api.us-east-1.amazonaws.com/Prod*

#### Screenshots, if available:

![AudioModeSpinner](https://user-images.githubusercontent.com/84412426/141523007-e3d892ee-d604-4922-83ae-4dbea3f15a67.jpg)

![AudioModeSpinner_Expanded](https://user-images.githubusercontent.com/84412426/141523035-ac7cd818-e1de-48a8-8aae-37d870093cff.jpg)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
